### PR TITLE
Prevent error in logstash.handler_tcp.TCPLogstashHandler.makePickle

### DIFF
--- a/logstash/formatter.py
+++ b/logstash/formatter.py
@@ -78,10 +78,8 @@ class LogstashFormatterBase(logging.Formatter):
 
     @classmethod
     def serialize(cls, message):
-        if sys.version_info < (3, 0):
-            return json.dumps(message)
-        else:
-            return bytes(json.dumps(message), 'utf-8')
+        return json.dumps(message)
+
 
 class LogstashFormatterVersion0(LogstashFormatterBase):
     version = 0


### PR DESCRIPTION
TypeError: descriptor 'encode' requires a 'str' object but received a 'bytes'