### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md


### PR DESCRIPTION
Include missing files in sdist for #9

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.3qWZXzD0kB
+ trap 'rm -rf /tmp/tmp.3qWZXzD0kB' EXIT
+ python -m venv /tmp/tmp.3qWZXzD0kB
+ python setup.py sdist -d /tmp/tmp.3qWZXzD0kB
running sdist
running check
reading manifest template 'MANIFEST.in'
writing manifest file 'MANIFEST'
creating python3-logstash-0.4.73
creating python3-logstash-0.4.73/logstash
making hard links in python3-logstash-0.4.73...
hard linking README.md -> python3-logstash-0.4.73
hard linking README.rst -> python3-logstash-0.4.73
hard linking setup.py -> python3-logstash-0.4.73
hard linking logstash/__init__.py -> python3-logstash-0.4.73/logstash
hard linking logstash/formatter.py -> python3-logstash-0.4.73/logstash
hard linking logstash/handler_amqp.py -> python3-logstash-0.4.73/logstash
hard linking logstash/handler_tcp.py -> python3-logstash-0.4.73/logstash
hard linking logstash/handler_udp.py -> python3-logstash-0.4.73/logstash
Creating tar archive
removing 'python3-logstash-0.4.73' (and everything under it)
+ cd /
+ /tmp/tmp.3qWZXzD0kB/bin/pip install /tmp/tmp.3qWZXzD0kB/python3-logstash-0.4.73.tar.gz
Processing /tmp/tmp.3qWZXzD0kB/python3-logstash-0.4.73.tar.gz
Installing collected packages: python3-logstash
  Running setup.py install for python3-logstash: started
    Running setup.py install for python3-logstash: finished with status 'done'
Successfully installed python3-logstash-0.4.73
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.3qWZXzD0kB
```
